### PR TITLE
set groups for items registered after mods are done loading

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,16 +1,33 @@
 minetest.register_on_mods_loaded(function()
-	for i,v in pairs(minetest.registered_items) do
-		local groups = v.groups
-		if v.type == "node" then
+	for i, def in pairs(minetest.registered_items) do
+		local groups = def.groups
+		if def.type == "node" then
 			groups.node = 1
-		elseif v.type == "craft" then
+		elseif def.type == "craft" then
 			groups.craftitem = 1
-		elseif v.type == "tool" then
+		elseif def.type == "tool" then
 			groups.tool = 1
 		end
-		if v.type ~= "none" then
+		if def.type ~= "none" then
 			groups.any = 1
 		end
 		minetest.override_item(i,{groups=groups})
+	end
+
+	local old_register_item = minetest.register_item
+	function minetest.register_item(name, def)
+		local groups = def.groups or {}
+		if def.type == "node" then
+			groups.node = 1
+		elseif def.type == "craft" then
+			groups.craftitem = 1
+		elseif def.type == "tool" then
+			groups.tool = 1
+		end
+		if def.type ~= "none" then
+			groups.any = 1
+		end
+		def.groups = groups
+		old_register_item(name, def)
 	end
 end)


### PR DESCRIPTION
it's technically possible to register new items/nodes/tools after the mods finish loading, though i think players have to relog to get new definitions. i'm not aware of any mods or games that actually do that, but it's a "feature" i've been thinking about. 